### PR TITLE
updateGoldenFile BUGFIX: change perm arg from 644 to 0644

### DIFF
--- a/backend/server_test.go
+++ b/backend/server_test.go
@@ -129,5 +129,5 @@ func sfxFakeResponseFile(testCase TestCase) string {
 }
 
 func updateGoldenFile(testCase TestCase, bytes []byte) error {
-	return os.WriteFile(goldenFile(testCase), bytes, 644)
+	return os.WriteFile(goldenFile(testCase), bytes, 0644)
 }


### PR DESCRIPTION
* Fixed bad perm argument to `os.WriteFile` which was setting perms to `--w----r--` instead of `-rw-r--r--`