### PR TITLE
backend/Dockerfile.debug: restore `apk add build-base` [+]

### DIFF
--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -2,7 +2,8 @@
 FROM golang:1.17 AS builder
 WORKDIR /app
 COPY . .
-RUN go mod tidy && \
+RUN apk add build-base && \
+    go mod tidy && \
     go install -v ./... && \
     go build -gcflags="all=-N -l" -o resolve && \
     go clean -modcache && \


### PR DESCRIPTION
While switching to golang:1.17 image allowed for `go install` of delve to complete without cgo-related errors, apparently the installed `dlv` can't be executed at runtime:

/app # ./util/dlv
/bin/sh: ./util/dlv: not found

I restored build-base and this cleared the error.  After finishing CI setup we can circle back and see if we can get this worked out, for a smaller and faster-built image.