### PR TITLE
backend/Dockerfile.debug: switch back to golang:1.17-alpine [+]

### DIFF
--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.17 AS builder
+FROM golang:1.17-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN apk add build-base && \


### PR DESCRIPTION
Didn't commit this with the `apk add build-base` but have to because it's alpine-specific.