### PR TITLE
Add diff utility and output diff golden vs actual on test fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 resolve
 coverage.out
 
+// Temporary files for diff'ing of actual values against golden files.
+backend/testdata/server/tmp/*
+!backend/testdata/server/tmp/actual/
+backend/testdata/server/tmp/actual/*
+!backend/testdata/server/tmp/actual/.gitkeep
+
 //for Vlad's dev environment
 go.work
 c.out

--- a/backend/sfx/request.go
+++ b/backend/sfx/request.go
@@ -38,7 +38,8 @@ type sfxContextObjectRequestBody struct {
 var sfxRequestTemplate string
 
 // SFX service URL
-var sfxURL string = "http://sfx.library.nyu.edu/sfxlcl41"
+const DefaultSFXURL = "http://sfx.library.nyu.edu/sfxlcl41"
+var sfxURL = DefaultSFXURL
 
 // Construct and run the actual POST request to the SFX server
 // Expects an XML string in a SFXContextObjectRequest obj which will be appended to the PostForm params

--- a/backend/util/util.go
+++ b/backend/util/util.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"os/exec"
+)
+
+func Diff(path1 string, path2 string) (string, error) {
+	diffCmd := "diff"
+
+	outputBytes, err := exec.Command(diffCmd, "-r", path1, path2).CombinedOutput()
+	if err != nil {
+		switch err.(type) {
+			case *exec.ExitError:
+				// `diff` ran successfully with non-zero exit code.  Report the
+				// differences.
+			default:
+				// `diff` command failed to run.
+				return "", err
+		}
+	}
+
+	return string(outputBytes), nil
+}


### PR DESCRIPTION
* `TestResponseJSONRoute`: on test fail, output diff golden vs. actual files if `diff` command is available, otherwise show paths to files to manually diff
* Extract const `DefaultSFXURL`