### PR TITLE
helpers.js: optional chaining operator added

### DIFF
--- a/frontend/src/aux/helpers.js
+++ b/frontend/src/aux/helpers.js
@@ -3,7 +3,7 @@ const getLinks = (jsonData) => {
 };
 
 const getCoverageStatement = (link) => {
-  return link.coverage[0].coverage_text[0].threshold_text[0].coverage_statement.join('. ');
+  return link.coverage[0].coverage_text[0].threshold_text[0].coverage_statement?.join('. ');
 };
 
 export { getLinks, getCoverageStatement };


### PR DESCRIPTION
some OpenURLs does not have "coverage_statement", so we need to access an object's property before invoking a ".join" method